### PR TITLE
set default trace key

### DIFF
--- a/lib/tracer.ex
+++ b/lib/tracer.ex
@@ -11,13 +11,13 @@ defmodule Tracer do
           span_id: binary(),
           should_sample?: boolean()
         }
-  def get_trace_context(key) do
+  def get_trace_context(key \\ self()) do
     TraceContext.get(key)
     |> Map.from_struct()
   end
 
   @spec get_trace_header(any) :: {binary(), binary()}
-  def get_trace_header(key) do
+  def get_trace_header(key \\ self()) do
     Plug.get_trace_header(TraceContext.get(key))
   end
 end

--- a/lib/tracer/middleware/trace_header.ex
+++ b/lib/tracer/middleware/trace_header.ex
@@ -4,7 +4,7 @@ defmodule Tracer.Middleware.TraceHeader do
   @impl Tesla.Middleware
   @spec call(Tesla.Env.t(), Tesla.Env.stack(), keyword()) :: Tesla.Env.result()
   def call(env, next, options) do
-    trace_key = Keyword.get(options, :trace_key)
+    trace_key = Keyword.get(options, :trace_key, self())
     {header, value} = Tracer.get_trace_header(trace_key)
 
     env

--- a/lib/tracer/plug.ex
+++ b/lib/tracer/plug.ex
@@ -13,7 +13,7 @@ defmodule Tracer.Plug do
   @impl Plug
   @spec call(Plug.Conn.t(), keyword) :: Plug.Conn.t()
   def call(conn, opts) do
-    key = Keyword.get(opts, :trace_key)
+    key = Keyword.get(opts, :trace_key, self())
     header = Keyword.get(opts, :trace_context_header, "x-cloud-trace-context")
     project_id = Keyword.get(opts, :project_id, "my-project")
 

--- a/test/tracer/middleware/trace_header_test.exs
+++ b/test/tracer/middleware/trace_header_test.exs
@@ -7,13 +7,12 @@ defmodule Tracer.Middleware.TraceHeaderTest do
 
   describe "call/3" do
     test "adds trace header" do
-      trace_key = self()
       context = TraceContext.new("x-cloud-trace-context", "my-project")
-      :ok = TraceContext.put(trace_key, context)
+      :ok = TraceContext.put(self(), context)
 
-      assert {:ok, env} = @middleware.call(%Env{}, [], trace_key: trace_key)
+      assert {:ok, env} = @middleware.call(%Env{}, [], [])
 
-      header = Tracer.get_trace_header(trace_key)
+      header = Tracer.get_trace_header()
 
       assert env.headers == [header]
     end

--- a/test/tracer_test.exs
+++ b/test/tracer_test.exs
@@ -17,7 +17,7 @@ defmodule TracerTest do
       trace_key = self()
       :ok = TraceContext.put(trace_key, context)
 
-      fetched_context = Tracer.get_trace_context(trace_key)
+      fetched_context = Tracer.get_trace_context()
       assert is_map(fetched_context)
       assert fetched_context.trace_id == context.trace_id
       assert fetched_context.span_id == context.span_id


### PR DESCRIPTION
Use `self()` as default trace key